### PR TITLE
[Refactor] ServerCommand use PrintHelpTrait

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "sonypradana/php-library": "^0.10.5",
+        "sonypradana/php-library": "^0.11",
         "react/socket": "^1.12"
     },
     "require-dev": {


### PR DESCRIPTION
- using `PrintHelpTrait::ptintCommandHelp()` and `PrintHelpTrait::PrintOptionHelp()`to render help command.
- add new command to configure setting printer.