### PR TITLE
[Chore] Fix PhpStan Error

### DIFF
--- a/src/Commands/ServeCommand.php
+++ b/src/Commands/ServeCommand.php
@@ -141,21 +141,17 @@ final class ServeCommand extends Command
         // set socket.enable
         $uri = $this->option('uri', '127.0.0.1:8080');
         if ($uri !== true) {
-            // @phpstan-ignore-next-line
             Config::set('socket.uri', $uri);
         }
 
         // set print.line
-        // @phpstan-ignore-next-line
         $line = $this->option('line', 2);
         if ($line !== true) {
             Config::set('print.line', (int) $line);
         }
 
         // set print.line
-        // @phpstan-ignore-next-line
         $var_end = $this->option('varend', false);
-        // @phpstan-ignore-next-line
         Config::set('print.var.end', $var_end);
     }
 }

--- a/src/Commands/ServeCommand.php
+++ b/src/Commands/ServeCommand.php
@@ -84,7 +84,6 @@ final class ServeCommand extends Command
             '--uri'     => 'Config, set default socket uri',
         ];
 
-        // @phpstan-ignore-next-line
         $this->command_relation = [
             'serve'     => ['[uri:port]'],
             'config'    => ['[option]'],

--- a/src/Config.php
+++ b/src/Config.php
@@ -6,7 +6,7 @@ namespace Here;
 
 final class Config
 {
-    /** @var array<string, int|string|bool> */
+    /** @var array<string, string|bool|int|null> */
     private static $configs = [];
 
     /**
@@ -36,7 +36,7 @@ final class Config
     /**
      * Save current config to config file.
      *
-     * @param array<string, int|string|bool> $configs
+     * @param array<string, string|bool|int|null> $configs
      *
      * @return void
      */
@@ -74,8 +74,8 @@ final class Config
     /**
      * Set/create array item of config.
      *
-     * @param string          $key
-     * @param int|string|bool $val
+     * @param string               $key
+     * @param string|bool|int|null $val
      *
      * @return void
      */
@@ -99,7 +99,7 @@ final class Config
     /**
      * Get cached config.
      *
-     * @return array<string, int|string|bool>
+     * @return array<string, string|bool|int|null>
      */
     public static function all()
     {


### PR DESCRIPTION
remove fix-phpstan-igonre-next-line
- `Config::$config` with var type `array<string, string|bool|int|null>`.
- `Config::save()` with param type `array<string, string|bool|int|null>`.
- `Config::set()` with param type `array<string, string|bool|int|null>`.
- `Config::all()` with return type `array<string, string|bool|int|null>`.
- `System\Console\Command::option`  with param and return type `array<string, string|bool|int|null>`.
- `System\Console\Command::$command_relation:`  with var `type array<string, array<int, string>>`.
