### PR TITLE
[Style] Redesigned Array Printer Style

### DIFF
--- a/here.config.json
+++ b/here.config.json
@@ -1,6 +1,7 @@
 {
     "print.line": 2,
     "print.var.end": false,
+    "print.var.max": 5,
     "socket.enable": false,
     "socket.uri": "127.0.0.1:8080"
 }

--- a/src/Abstracts/VarPrinter.php
+++ b/src/Abstracts/VarPrinter.php
@@ -17,12 +17,18 @@ abstract class VarPrinter
     /** @var int tab indet dept */
     protected $dept = 3;
 
+    /** @var int current line print */
+    protected $current_line = 0;
+
+    /** @var int max line to be print */
+    protected $max_line = 5;
+
     /**
      * @param Style $style
      */
     public function __construct($style)
     {
-        $this->style = $style;
+        $this->style    = $style;
     }
 
     /**
@@ -83,6 +89,30 @@ abstract class VarPrinter
     public function dept(int $dept)
     {
         $this->dept = $dept;
+
+        return $this;
+    }
+
+    /**
+     * Set current line print.
+     *
+     * @return self
+     */
+    public function currentLine(int $current_line)
+    {
+        $this->current_line = $current_line;
+
+        return $this;
+    }
+
+    /**
+     * Set max line to be print.
+     *
+     * @return self
+     */
+    public function maxLine(int $max_line)
+    {
+        $this->max_line = $max_line;
 
         return $this;
     }

--- a/src/Abstracts/VarPrinter.php
+++ b/src/Abstracts/VarPrinter.php
@@ -14,8 +14,8 @@ abstract class VarPrinter
     /** @var mixed */
     protected $var;
 
-    /** @var int tab indet dept */
-    protected $dept = 3;
+    /** @var int tab indet depth */
+    protected $tab_size = 3;
 
     /** @var int current line print */
     protected $current_line = 0;
@@ -82,13 +82,13 @@ abstract class VarPrinter
     }
 
     /**
-     * Set tab indet dept.
+     * Set tab indet depth.
      *
      * @return self
      */
-    public function dept(int $dept)
+    public function tabSize(int $tab_size)
     {
-        $this->dept = $dept;
+        $this->tab_size = $tab_size;
 
         return $this;
     }

--- a/src/Abstracts/VarPrinter.php
+++ b/src/Abstracts/VarPrinter.php
@@ -14,6 +14,9 @@ abstract class VarPrinter
     /** @var mixed */
     protected $var;
 
+    /** @var int tab indet dept */
+    protected $dept = 3;
+
     /**
      * @param Style $style
      */
@@ -70,5 +73,17 @@ abstract class VarPrinter
         $str = $var;
 
         return \strlen($str);
+    }
+
+    /**
+     * Set tab indet dept.
+     *
+     * @return self
+     */
+    public function dept(int $dept)
+    {
+        $this->dept = $dept;
+
+        return $this;
     }
 }

--- a/src/Commands/ServeCommand.php
+++ b/src/Commands/ServeCommand.php
@@ -99,6 +99,7 @@ final class ServeCommand extends Command
             '--init'    => 'Config, create new Here configuration in root application',
             '--line'    => 'Config, set default printer up/down line count',
             '--var-end' => 'Config, set default printer up/down line count',
+            '--var-max' => 'Config, set default printer maximum line to be print',
             '--socket'  => 'Config, enable/disable socket reporting',
             '--uri'     => 'Config, set default socket uri',
         ];
@@ -171,6 +172,12 @@ final class ServeCommand extends Command
         // set print.line
         $var_end = $this->option('varend', false);
         Config::set('print.var.end', $var_end);
+
+        // set print.var.max
+        $max_line = $this->option('varmax', false);
+        if ($line !== true) {
+            Config::set('print.var.max', (int) $max_line);
+        }
     }
 
     private function promt(): bool

--- a/src/Styles/ArrayStyle.php
+++ b/src/Styles/ArrayStyle.php
@@ -11,10 +11,30 @@ class ArrayStyle extends VarPrinter
 {
     public function render(): Style
     {
-        $var = $this->sanitize($this->var);
+        /** @var array<int|string, mixed> */
+        $var = $this->var;
 
-        return $this->style
-            ->new_lines()
-            ->push($var)->textGreen();
+        $this->style
+            ->push('array:')->textBlue()
+            ->push(count($var))->textBlue()
+            ->push(' [')->textYellow()
+        ;
+
+        foreach ($var as $key => $value) {
+            $this->style->new_lines();
+            $this->style->repeat(' ', $this->dept * 2);
+            $this->style->push($key)->textLightGreen();
+            $this->style->push(' => ')->textYellow();
+
+            $style = is_array($value)
+                ? new ArrayStyle($this->style)
+                : new VarStyle($this->style);
+            $this->style = $style->ref($value)->dept($this->dept + 1)->render();
+        }
+
+        $this->style->new_lines()->repeat(' ', ($this->dept * 2) - 2);
+        $this->style->push(']')->textYellow();
+
+        return $this->style;
     }
 }

--- a/src/Styles/ArrayStyle.php
+++ b/src/Styles/ArrayStyle.php
@@ -33,12 +33,12 @@ class ArrayStyle extends VarPrinter
         foreach ($var as $key => $value) {
             $this->current_line++;
             if ($this->current_line > $this->max_line) {
-                $this->style->new_lines()->repeat(' ', 4)->push('...')->textDim();
+                $this->style->new_lines()->repeat(' ', $this->tab_size * 2)->push('...')->textDim();
                 break;
             }
 
             $this->style->new_lines();
-            $this->style->repeat(' ', $this->dept * 2);
+            $this->style->repeat(' ', $this->tab_size * 2);
             $this->style->push($key)->textLightGreen();
             $this->style->push(' => ')->textYellow();
 
@@ -47,13 +47,13 @@ class ArrayStyle extends VarPrinter
                 : new VarStyle($this->style);
 
             $style->ref($value)
-                ->dept($this->dept + 1)
+                ->tabSize($this->tab_size + 1)
                 ->currentLine($this->current_line)
             ;
             $this->style = $style->render();
         }
 
-        $this->style->new_lines()->repeat(' ', ($this->dept * 2) - 2);
+        $this->style->new_lines()->repeat(' ', ($this->tab_size * 2) - 2);
         $this->style->push(']')->textYellow();
 
         return $this->style;

--- a/src/Styles/ClassStyle.php
+++ b/src/Styles/ClassStyle.php
@@ -5,18 +5,34 @@ declare(strict_types=1);
 namespace Here\Styles;
 
 use Here\Abstracts\VarPrinter;
+use Here\Config;
 use ReflectionClass;
 use ReflectionProperty;
 use System\Console\Style\Style;
 
 class ClassStyle extends VarPrinter
 {
+    /**
+     * @param Style $style
+     */
+    public function __construct($style)
+    {
+        parent::__construct($style);
+        $this->max_line = (int) Config::get('print.var.max', 5);
+    }
+
     public function render(): Style
     {
         $obj   = (object) $this->var;
         $class = new ReflectionClass($obj);
 
         foreach ($class->getDefaultProperties() as $name => $value) {
+            $this->current_line++;
+            if ($this->current_line > $this->max_line) {
+                $this->style->new_lines()->repeat(' ', 4)->push('...')->textDim();
+                break;
+            }
+
             $visible  = '';
             $property = $class->getProperty($name);
             $property->setAccessible(true);
@@ -42,11 +58,15 @@ class ClassStyle extends VarPrinter
             $this->style->push($name);
             $this->style->push(': ')->textYellow();
 
-            $var = is_array($value)
+            $style = is_array($value)
                 ? new ArrayStyle($this->style)
                 : new VarStyle($this->style);
 
-            $this->style = $var->ref($value)->render();
+            $style->ref($value)
+                ->dept($this->dept + 1)
+            ;
+
+            $this->style = $style->ref($value)->render();
         }
 
         if ($class->hasMethod('__tostring')) {

--- a/src/Styles/ClassStyle.php
+++ b/src/Styles/ClassStyle.php
@@ -63,7 +63,7 @@ class ClassStyle extends VarPrinter
                 : new VarStyle($this->style);
 
             $style->ref($value)
-                ->dept($this->dept + 1)
+                ->tabSize($this->tab_size + 1)
             ;
 
             $this->style = $style->ref($value)->render();

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -29,6 +29,7 @@ final class ConfigTest extends TestCase
         $this->assertEquals([
             'print.line'    => 2,
             'print.var.end' => false,
+            'print.var.max' => 5,
             'socket.enable' => false,
             'socket.uri'    => '127.0.0.1:8080',
         ], Config::all());
@@ -44,6 +45,7 @@ final class ConfigTest extends TestCase
         $this->assertEquals([
             'print.line'    => 2,
             'print.var.end' => false,
+            'print.var.max' => 5,
             'socket.enable' => false,
             'socket.uri'    => '127.0.0.1:8080',
         ], Config::all());


### PR DESCRIPTION
Redesign readable array print.

### Why
- More readable.
- More color.
- More control (set maximum line to be print, include `ClassStyle::class`.